### PR TITLE
Implement passing of encryption key file to proxmox-backup-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ export PBS_DATASTORE="backups"
 export PBS_API_TOKEN_SECRET="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 export PBS_FINGERPRINT="AA:BB:CC:..."
 
+# Omit following if you don't want encryption enabled.
+export PBS_ENCRYPTION_KEYFILE="/path/to/key.enc"
+
 # Option 2: Config file
 # Config files are checked in priority order:
 #   1. ~/.config/zpbs-backup/pbs.conf  (per-user)
@@ -136,9 +139,16 @@ PBS_DATASTORE="backups"
 PBS_API_TOKEN_SECRET="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 PBS_FINGERPRINT="AA:BB:CC:..."
 
+# Omit following if you don't want encryption enabled.
+PBS_ENCRYPTION_KEYFILE="/path/to/key.enc"
+
 # Shell variable interpolation is supported:
 # PBS_REPOSITORY="${PBS_USER}!${PBS_API_TOKEN_NAME}@${PBS_SERVER}:${PBS_DATASTORE}"
 ```
+
+> **Disclaimer: Do not mix usage of environment variables and the configuration
+> file. Either define all variables as environment variables or in the
+> configuration file.
 
 Verify your configuration:
 

--- a/src/zpbs_backup/cli.py
+++ b/src/zpbs_backup/cli.py
@@ -344,6 +344,10 @@ def show_config(verbose: bool, json_output: bool) -> None:
     click.echo(f"  Datastore:        {config.datastore or '(unknown)'}")
     click.echo(f"  Token secret:     {mask_secret(config.password)}")
     click.echo(f"  Fingerprint:      {config.fingerprint or '(not set)'}")
+    if config.keyfile is None:
+        click.echo("  Encryption:       Disabled")
+    else:
+        click.echo(f"  Encryption:       Enabled using '{config.keyfile}'")
 
     if verbose:
         click.echo("")
@@ -384,6 +388,7 @@ def _show_config_json(config: PBSConfig) -> None:
         "api_token_name": config.token_name,
         "datastore": config.datastore,
         "fingerprint": config.fingerprint,
+        "keyfile": config.keyfile,
         "repository": config.repository,
         "active_source": config.active_source,
         "connected": connected,

--- a/src/zpbs_backup/config.py
+++ b/src/zpbs_backup/config.py
@@ -28,6 +28,7 @@ _ENV_VAR_NAMES = [
     "PBS_API_TOKEN_NAME",
     "PBS_SERVER",
     "PBS_DATASTORE",
+    "PBS_ENCRYPTION_KEYFILE",
     # Metrics / observability
     "ZPBS_PUSHGATEWAY",
     # Legacy aliases
@@ -53,6 +54,7 @@ class PBSConfig:
     repository: str
     password: str | None = None
     fingerprint: str | None = None
+    keyfile: str | None = None # None implies "do not encrypt"
 
     # Parsed display fields
     user: str | None = None
@@ -256,6 +258,7 @@ def _config_from_variables(variables: dict[str, str]) -> PBSConfig:
     )
 
     fingerprint = variables.get("PBS_FINGERPRINT", variables.get("FINGERPRINT"))
+    keyfile = variables.get("PBS_ENCRYPTION_KEYFILE", None)
 
     # Parse repository for display fields if not set from individual vars
     if repository and not all([user, token_name, server, datastore]):
@@ -269,6 +272,7 @@ def _config_from_variables(variables: dict[str, str]) -> PBSConfig:
         token_name=token_name,
         server=server,
         datastore=datastore,
+        keyfile=keyfile,
     )
 
 

--- a/src/zpbs_backup/pbs.py
+++ b/src/zpbs_backup/pbs.py
@@ -297,6 +297,11 @@ class PBSClient:
             backup_id,
         ]
 
+        if self.config.keyfile is not None:
+            args.extend(
+                ["--keyfile", self.config.keyfile]
+            )
+
         if namespace:
             args.extend(["--ns", namespace])
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -238,6 +238,7 @@ class TestLoadConfig:
         assert config.sources.get("PBS_REPOSITORY") == "environment"
 
     def test_individual_env_vars(self, monkeypatch):
+        monkeypatch.delenv("PBS_REPOSITORY")
         monkeypatch.setenv("PBS_USER", "backup@pbs")
         monkeypatch.setenv("PBS_API_TOKEN_NAME", "mytoken")
         monkeypatch.setenv("PBS_SERVER", "pbs.example.com")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -258,21 +258,28 @@ class TestLoadConfig:
         config = load_config()
         assert config.keyfile is None
 
-    def test_config_file_loading(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize("with_encryption", [False, True])
+    def test_config_file_loading(self, with_encryption, tmp_path, monkeypatch):
         # Clear any env vars
         for var in [
             "PBS_REPOSITORY", "PBS_PASSWORD", "PBS_FINGERPRINT",
             "PBS_USER", "PBS_API_TOKEN_NAME", "PBS_SERVER", "PBS_DATASTORE",
-            "PBS_API_TOKEN_SECRET", "REPOSITORY", "PASSWORD", "FINGERPRINT",
+            "PBS_API_TOKEN_SECRET", "PBS_ENCRYPTION_KEYFILE", "REPOSITORY", 
+            "PASSWORD", "FINGERPRINT",
         ]:
             monkeypatch.delenv(var, raising=False)
 
         # Create a config file
         conf = tmp_path / "pbs.conf"
-        conf.write_text(
+
+        contents = (
             "PBS_REPOSITORY=backup@pbs!tok@host:ds\n"
             "PBS_PASSWORD=secret\n"
         )
+        if with_encryption:
+            contents += "PBS_ENCRYPTION_KEYFILE=/path/to/key.enc\n"
+            
+        conf.write_text(contents)
 
         # Patch CONFIG_PATHS to use our temp file
         monkeypatch.setattr(
@@ -282,11 +289,17 @@ class TestLoadConfig:
         assert config.repository == "backup@pbs!tok@host:ds"
         assert config.sources.get("PBS_REPOSITORY") == str(conf)
 
+        if with_encryption:
+            assert config.keyfile == "/path/to/key.enc"
+        else:
+            assert config.keyfile is None
+
     def test_no_config_raises(self, monkeypatch):
         for var in [
             "PBS_REPOSITORY", "PBS_PASSWORD", "PBS_FINGERPRINT",
             "PBS_USER", "PBS_API_TOKEN_NAME", "PBS_SERVER", "PBS_DATASTORE",
-            "PBS_API_TOKEN_SECRET", "REPOSITORY", "PASSWORD", "FINGERPRINT",
+            "PBS_API_TOKEN_SECRET", "PBS_ENCRYPTION_KEYFILE", "REPOSITORY", 
+            "PASSWORD", "FINGERPRINT",
         ]:
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setattr(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,9 +244,19 @@ class TestLoadConfig:
         monkeypatch.setenv("PBS_SERVER", "pbs.example.com")
         monkeypatch.setenv("PBS_DATASTORE", "backups")
         monkeypatch.setenv("PBS_API_TOKEN_SECRET", "secret")
+        monkeypatch.setenv("PBS_ENCRYPTION_KEYFILE", "/path/to/key.enc")
         config = load_config()
         assert config.repository == "backup@pbs!mytoken@pbs.example.com:backups"
         assert config.password == "secret"
+        assert config.keyfile == "/path/to/key.enc"
+
+    def test_no_encryption_is_valid_config(self, monkeypatch):
+        monkeypatch.setenv("PBS_REPOSITORY", "backup@pbs!tok@host:ds")
+        monkeypatch.setenv("PBS_PASSWORD", "secret")
+
+        monkeypatch.delenv("PBS_ENCRYPTION_KEYFILE", raising=False)
+        config = load_config()
+        assert config.keyfile is None
 
     def test_config_file_loading(self, tmp_path, monkeypatch):
         # Clear any env vars

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -161,6 +161,45 @@ class TestPBSClientBackup:
 
         assert result.returncode == 0
 
+    @pytest.mark.parametrize("with_encryption", [False, True])
+    def test_backup_passes_right_arguments_to_backup_client(self, with_encryption, monkeypatch):
+        from zpbs_backup.config import PBSConfig
+        from zpbs_backup.pbs import PBSClient
+
+        config = PBSConfig(
+            repository="user@realm!tokenname@server:datastore",
+            password="test-token",
+            keyfile="/path/to/key.enc" if with_encryption else None
+        )
+        client = PBSClient(config)
+
+        monkeypatch.setattr("os.environ", {"USERS_ENV_VAR1": "VALUE1", "USERS_ENV_VAR2": "VALUE2"})
+
+        with umock.patch("subprocess.run") as subprocess_run:
+            client.backup(
+                backup_id="test-backup",
+                source_path="/test/path",
+            )
+            assert subprocess_run.call_args == umock.call(
+                [
+                    "proxmox-backup-client",
+                    "backup",
+                    "root.pxar:/test/path",
+                    "--backup-id",
+                    "test-backup",
+                ] + (["--keyfile", "/path/to/key.enc"] if with_encryption else []),
+                env={
+                    "PBS_REPOSITORY": "user@realm!tokenname@server:datastore",
+                    "PBS_PASSWORD": "test-token",
+                    "USERS_ENV_VAR1": "VALUE1",
+                    "USERS_ENV_VAR2": "VALUE2",
+                },
+                capture_output=False,
+                text=True,
+                check=False,
+                timeout=None,
+            )
+
 
 class TestParseServerAddress:
     """Tests for _parse_server_address."""

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -1,7 +1,7 @@
 """Tests for PBS client wrapper."""
 
+import unittest.mock as umock
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
 
 import pytest
 
@@ -188,27 +188,27 @@ class TestClockSkew:
 
     def test_skew_zero_when_server_matches_local(self):
         now = datetime.now(timezone.utc)
-        with patch.object(PBSClient, "get_server_time", return_value=now):
+        with umock.patch.object(PBSClient, "get_server_time", return_value=now):
             skew = self._client().get_clock_skew_seconds()
         assert skew is not None
         assert abs(skew) < 1.0
 
     def test_skew_positive_when_server_ahead(self):
         future = datetime.now(timezone.utc) + timedelta(seconds=120)
-        with patch.object(PBSClient, "get_server_time", return_value=future):
+        with umock.patch.object(PBSClient, "get_server_time", return_value=future):
             skew = self._client().get_clock_skew_seconds()
         assert skew is not None
         assert 119 < skew < 121
 
     def test_skew_negative_when_server_behind(self):
         past = datetime.now(timezone.utc) - timedelta(seconds=90)
-        with patch.object(PBSClient, "get_server_time", return_value=past):
+        with umock.patch.object(PBSClient, "get_server_time", return_value=past):
             skew = self._client().get_clock_skew_seconds()
         assert skew is not None
         assert -91 < skew < -89
 
     def test_skew_none_when_probe_fails(self):
-        with patch.object(PBSClient, "get_server_time", return_value=None):
+        with umock.patch.object(PBSClient, "get_server_time", return_value=None):
             assert self._client().get_clock_skew_seconds() is None
 
     def test_get_server_time_returns_none_when_no_server_configured(self):


### PR DESCRIPTION
Hi there! I found `zpbs-backup` to be quite useful to streamline the backups of my zfs datasets. Many thanks for developing it and sharing it! 

I use encryption for my VM backups, so I naturally wanted to do the same with the zfs backups. Realized your tool doesn't support it, so I decided to add it. 

Below is just a copy of the commit titles, which should give a good overview of what I did.

- **Fix an isolation issue with a test case**
- **Implement PBS_ENCRYPTION_KEYFILE pass to config**
- **Verify parsing of encryption key file from config file**
- **Use unittest.mock as module instead of importing from it in test_pbs.py**
- **Pass encryption key file to the client if it is available in config**
- **Add documentation about PBS_ENCRYPTION_KEYFILE**
- **Add encryption entry for show-config**

Please let me know if this works or if you need something to change. I'm also happy to discuss another approach if you had something else in mind.

Cheers,
Caglar