### PR TITLE
Fix systemd service failing due to incorrectly finding another zpbs-backup execution

### DIFF
--- a/systemd/zpbs-backup.service
+++ b/systemd/zpbs-backup.service
@@ -10,7 +10,7 @@ ExecStart=/usr/local/bin/zpbs-backup run
 # Load PBS credentials from file if not in environment
 EnvironmentFile=-/etc/zpbs-backup/pbs.conf
 # Prevent multiple simultaneous runs
-ExecStartPre=/bin/sh -c '! pgrep -f "zpbs-backup run"'
+ExecStartPre=/bin/sh -c '! pgrep -f "zpbs-[b]ackup run" >/dev/null'
 
 # Security hardening
 ProtectSystem=strict


### PR DESCRIPTION
The systemd service has

```
ExecStartPre=/bin/sh -c '! pgrep -f "zpbs-backup run"'
```

This translates to "Proceed with running the service if `/bin/sh -c '! pgrep -f "zpbs-backup run"'` returns 0.

However `/bin/sh -c '! pgrep -f "zpbs-backup run"` always returns non-zero because `pgrep` finds the very `/bin/sh` process that this call initiated. To prevent that, I slightly changed the pgrep pattern to include a valid regex. Since the valid regex will not match the string defining the regex, this prevents the call from finding its own process.

I'm on fedora 44. I wonder if this behaves any differently in other systems, or whether my conclusion here was wrong?
