### PR TITLE
feat: configurable backup-id separator (ZPBS_BACKUP_ID_SEPARATOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configurable backup-id separator via `ZPBS_BACKUP_ID_SEPARATOR` (env or config file; default `-`). A multi-character separator such as `--` yields **reversible** backup-ids — you can recover the dataset path from the PBS group name by stripping the host and splitting on the separator — which the default `-` cannot guarantee, since `-` is also legal in ZFS dataset names (`pool/a-b` and `pool/a/b` both flatten to `pool-a-b`). The separator joins the hostname prefix too, so IDs split uniformly; it is validated against the PBS backup-id character set. Default behavior is unchanged.
+
 ## [0.8.0] - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -348,11 +348,38 @@ sudo systemctl start zpbs-backup.timer
 
 ## Backup ID Format
 
-Backup IDs are generated as `{hostname}-{dataset-with-slashes-replaced}`:
+Backup IDs are generated as `{hostname}{sep}{dataset-with-slashes-replaced}`,
+where `{sep}` is the configurable **backup-id separator** (default `-`):
 - Dataset `tank/files/downloads` on host `storage-server`
 - Backup ID: `storage-server-tank-files-downloads`
 
-This maintains compatibility with existing backup IDs from the bash scripts.
+This default maintains compatibility with existing backup IDs from the bash
+scripts.
+
+### Reversible IDs (`ZPBS_BACKUP_ID_SEPARATOR`)
+
+Because the default separator (`-`) is also a legal character in ZFS dataset
+names, the default ID is **not reversible**: a `-` in the ID may be a path
+separator or part of a name (`pool/a-b` and `pool/a/b` both flatten to
+`pool-a-b`). If you need self-describing, unambiguous IDs — e.g. to recover the
+dataset layout from PBS group names alone during disaster recovery — set a
+multi-character separator that your dataset names do not contain:
+
+```bash
+# environment or /etc/zpbs-backup/pbs.conf
+export ZPBS_BACKUP_ID_SEPARATOR="--"
+```
+
+- Dataset `local-hdd/encrypted/device-backups` on host `s1-nas01`
+- Backup ID: `s1-nas01--local-hdd--encrypted--device-backups`
+- Recover the path: strip the host, then split the remainder on `--`.
+
+The separator joins the hostname prefix too, so the whole ID splits uniformly.
+It must be non-empty and use only PBS-backup-id characters (`[A-Za-z0-9_.-]`).
+Reversibility holds only while no dataset name component contains the separator
+or leads/trails with `-`. **Changing the separator changes every ID**, so
+existing backup groups become orphans (prune them with
+`proxmox-backup-client` and re-seed).
 
 ## Namespace Strategy
 

--- a/src/zpbs_backup/backup.py
+++ b/src/zpbs_backup/backup.py
@@ -129,7 +129,7 @@ class BackupOrchestrator:
                 plan.append((ds, True, None))
                 continue
 
-            backup_id = ds.get_backup_id(self.hostname)
+            backup_id = ds.get_backup_id(self.hostname, self.config.backup_id_separator)
             namespace = ds.namespace or ds.get_auto_namespace(self.hostname)
             last_backup = self.client.get_last_backup_time(backup_id, namespace)
 
@@ -215,7 +215,7 @@ class BackupOrchestrator:
             BackupResult with outcome
         """
         start_time = datetime.now()
-        backup_id = dataset.get_backup_id(self.hostname)
+        backup_id = dataset.get_backup_id(self.hostname, self.config.backup_id_separator)
         namespace = dataset.namespace or dataset.get_auto_namespace(self.hostname)
         mountpoint = dataset.mountpoint
 
@@ -380,7 +380,7 @@ class PruneOrchestrator:
         Returns:
             True if successful
         """
-        backup_id = dataset.get_backup_id(self.hostname)
+        backup_id = dataset.get_backup_id(self.hostname, self.config.backup_id_separator)
         namespace = dataset.namespace or dataset.get_auto_namespace(self.hostname)
         policy = get_retention_policy(dataset)
 

--- a/src/zpbs_backup/cli.py
+++ b/src/zpbs_backup/cli.py
@@ -77,7 +77,7 @@ def status(orphans: bool, json_output: bool) -> None:
     if json_output:
         output_data = []
         for ds in datasets:
-            backup_id = ds.get_backup_id(hostname)
+            backup_id = ds.get_backup_id(hostname, config.backup_id_separator)
             namespace = ds.namespace or ds.get_auto_namespace(hostname)
             last_backup = client.get_last_backup_time(backup_id, namespace) if ds.backup_enabled else None
 
@@ -116,7 +116,7 @@ def status(orphans: bool, json_output: bool) -> None:
         priority = str(ds.priority) if ds.backup_enabled else "-"
 
         if ds.backup_enabled:
-            backup_id = ds.get_backup_id(hostname)
+            backup_id = ds.get_backup_id(hostname, config.backup_id_separator)
             namespace = ds.namespace or ds.get_auto_namespace(hostname)
             last_backup = client.get_last_backup_time(backup_id, namespace)
             last_str = format_last_backup(last_backup)
@@ -137,15 +137,17 @@ def status(orphans: bool, json_output: bool) -> None:
 
     if orphans:
         click.echo("")
-        _show_orphans(client, datasets, hostname)
+        _show_orphans(client, datasets, hostname, config.backup_id_separator)
 
 
-def _show_orphans(client: PBSClient, datasets: list[Dataset], hostname: str) -> None:
+def _show_orphans(
+    client: PBSClient, datasets: list[Dataset], hostname: str, separator: str
+) -> None:
     """Show orphaned backup groups in PBS."""
     click.echo("Checking for orphaned backups...")
 
     # Get all expected backup IDs
-    expected_ids = {ds.get_backup_id(hostname) for ds in datasets if ds.backup_enabled}
+    expected_ids = {ds.get_backup_id(hostname, separator) for ds in datasets if ds.backup_enabled}
 
     # Get all backup groups from PBS
     all_groups = client.list_all_backup_groups()
@@ -263,7 +265,7 @@ def audit() -> None:
 
     # Get enabled datasets
     datasets = discover_datasets()
-    expected_ids = {ds.get_backup_id(hostname): ds for ds in datasets}
+    expected_ids = {ds.get_backup_id(hostname, config.backup_id_separator): ds for ds in datasets}
 
     click.echo(f"Auditing {len(datasets)} dataset(s)...")
     click.echo("")
@@ -271,7 +273,7 @@ def audit() -> None:
     # Check for never-backed-up datasets
     never_backed_up = []
     for ds in datasets:
-        backup_id = ds.get_backup_id(hostname)
+        backup_id = ds.get_backup_id(hostname, config.backup_id_separator)
         namespace = ds.namespace or ds.get_auto_namespace(hostname)
         last_backup = client.get_last_backup_time(backup_id, namespace)
         if last_backup is None:

--- a/src/zpbs_backup/config.py
+++ b/src/zpbs_backup/config.py
@@ -30,11 +30,17 @@ _ENV_VAR_NAMES = [
     "PBS_DATASTORE",
     # Metrics / observability
     "ZPBS_PUSHGATEWAY",
+    # Backup-id derivation
+    "ZPBS_BACKUP_ID_SEPARATOR",
     # Legacy aliases
     "REPOSITORY",
     "PASSWORD",
     "FINGERPRINT",
 ]
+
+# Default separator used when building a PBS backup-id from a dataset path.
+# "-" preserves historical ids ({hostname}-{path-with-slashes-as-dashes}).
+DEFAULT_BACKUP_ID_SEPARATOR = "-"
 
 
 @dataclass
@@ -59,6 +65,13 @@ class PBSConfig:
     token_name: str | None = None
     server: str | None = None
     datastore: str | None = None
+
+    # The string that replaces "/" in a dataset path (and joins the hostname
+    # prefix) when building the PBS backup-id. Default "-" keeps historical
+    # ids; set to e.g. "--" for a REVERSIBLE id when dataset name components
+    # may themselves contain "-" — split the id on the separator to recover
+    # the pool/dataset path (see Dataset.get_backup_id).
+    backup_id_separator: str = DEFAULT_BACKUP_ID_SEPARATOR
 
     # Source tracking: variable name → source description
     sources: dict[str, str] = field(default_factory=dict)
@@ -236,6 +249,26 @@ def _has_config(variables: dict[str, str]) -> bool:
     return has_repo or has_parts
 
 
+def validate_backup_id_separator(separator: str) -> str:
+    """Validate a backup-id separator.
+
+    The separator is inserted into PBS backup-ids, so it must be non-empty and
+    use only characters allowed in a PBS backup-id ([A-Za-z0-9_.-]).
+
+    Returns:
+        The separator unchanged if valid.
+
+    Raises:
+        ValueError: If the separator is empty or contains invalid characters.
+    """
+    if not separator or not re.fullmatch(r"[A-Za-z0-9_.\-]+", separator):
+        raise ValueError(
+            f"Invalid backup-id separator {separator!r}: must be non-empty and "
+            "contain only [A-Za-z0-9_.-] (the PBS backup-id character set)."
+        )
+    return separator
+
+
 def _config_from_variables(variables: dict[str, str]) -> PBSConfig:
     """Create PBSConfig from a dictionary of variables."""
     # Get repository — direct or composed from parts
@@ -261,6 +294,10 @@ def _config_from_variables(variables: dict[str, str]) -> PBSConfig:
     if repository and not all([user, token_name, server, datastore]):
         user, token_name, server, datastore = _parse_repository(repository)
 
+    separator = validate_backup_id_separator(
+        variables.get("ZPBS_BACKUP_ID_SEPARATOR") or DEFAULT_BACKUP_ID_SEPARATOR
+    )
+
     return PBSConfig(
         repository=repository,
         password=password,
@@ -269,6 +306,7 @@ def _config_from_variables(variables: dict[str, str]) -> PBSConfig:
         token_name=token_name,
         server=server,
         datastore=datastore,
+        backup_id_separator=separator,
     )
 
 

--- a/src/zpbs_backup/zfs.py
+++ b/src/zpbs_backup/zfs.py
@@ -123,13 +123,21 @@ class Dataset:
         parts = self.name.split("/", 1)
         return parts[1] if len(parts) > 1 else ""
 
-    def get_backup_id(self, hostname: str) -> str:
+    def get_backup_id(self, hostname: str, separator: str = "-") -> str:
         """Generate the backup ID for this dataset.
 
-        Format: {hostname}-{dataset-name-with-slashes-replaced}
+        Format: {hostname}{separator}{dataset-path-with-slashes-replaced}
+
+        ``separator`` replaces every "/" in the dataset path AND joins the
+        hostname prefix, so the id splits uniformly on it. The default "-"
+        preserves historical ids. A multi-character separator such as "--"
+        makes the id REVERSIBLE when dataset name components may themselves
+        contain "-" (strip the known hostname, then split on the separator to
+        recover pool/dataset paths) — provided no component itself contains
+        the separator.
         """
-        dataset_part = self.name.replace("/", "-")
-        return f"{hostname}-{dataset_part}"
+        dataset_part = self.name.replace("/", separator)
+        return f"{hostname}{separator}{dataset_part}"
 
     def get_auto_namespace(self, hostname: str) -> str:
         """Generate the auto-derived namespace.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ from zpbs_backup.config import (
     get_all_config_sources,
     load_config,
     mask_secret,
+    validate_backup_id_separator,
 )
 
 
@@ -328,3 +329,36 @@ class TestPBSConfigGetEnv:
     def test_active_source_unknown(self):
         config = PBSConfig(repository="backup@pbs!tok@host:ds")
         assert config.active_source == "unknown"
+
+
+class TestBackupIdSeparator:
+    def test_default_is_dash(self):
+        config = _config_from_variables({"PBS_REPOSITORY": "backup@pbs!tok@host:ds"})
+        assert config.backup_id_separator == "-"
+
+    def test_custom_double_dash(self):
+        config = _config_from_variables(
+            {"PBS_REPOSITORY": "backup@pbs!tok@host:ds", "ZPBS_BACKUP_ID_SEPARATOR": "--"}
+        )
+        assert config.backup_id_separator == "--"
+
+    def test_empty_value_falls_back_to_default(self):
+        config = _config_from_variables(
+            {"PBS_REPOSITORY": "backup@pbs!tok@host:ds", "ZPBS_BACKUP_ID_SEPARATOR": ""}
+        )
+        assert config.backup_id_separator == "-"
+
+    def test_invalid_separator_raises(self):
+        with pytest.raises(ValueError):
+            _config_from_variables(
+                {"PBS_REPOSITORY": "backup@pbs!tok@host:ds", "ZPBS_BACKUP_ID_SEPARATOR": "a/b"}
+            )
+
+    def test_validate_accepts_valid(self):
+        assert validate_backup_id_separator("--") == "--"
+        assert validate_backup_id_separator("_") == "_"
+
+    def test_validate_rejects_invalid(self):
+        for bad in ["", "/", "a b", "x/y"]:
+            with pytest.raises(ValueError):
+                validate_backup_id_separator(bad)

--- a/tests/test_zfs.py
+++ b/tests/test_zfs.py
@@ -125,6 +125,27 @@ class TestDataset:
         ds = Dataset(name="tank/data/files", properties={})
         assert ds.get_backup_id("myhost") == "myhost-tank-data-files"
 
+    def test_get_backup_id_default_matches_explicit_dash(self):
+        # Backward compatibility: the default equals the historical "-" form.
+        ds = Dataset(name="tank/data/files", properties={})
+        assert ds.get_backup_id("myhost") == ds.get_backup_id("myhost", "-")
+
+    def test_get_backup_id_custom_separator(self):
+        ds = Dataset(name="local-hdd/encrypted/device-backups", properties={})
+        assert (
+            ds.get_backup_id("s1-nas01", "--")
+            == "s1-nas01--local-hdd--encrypted--device-backups"
+        )
+
+    def test_get_backup_id_double_dash_is_reversible(self):
+        # The whole point of "--": recover the dataset path even when a
+        # component ("device-backups") contains the single-dash form.
+        host, name = "s1-nas01", "local-hdd/encrypted/device-backups"
+        ds = Dataset(name=name, properties={})
+        bid = ds.get_backup_id(host, "--")
+        recovered = "/".join(bid[len(host) + len("--"):].split("--"))
+        assert recovered == name
+
     def test_get_auto_namespace(self):
         ds = Dataset(name="tank/data/files", properties={})
         assert ds.get_auto_namespace("myhost") == "myhost/tank/data/files"


### PR DESCRIPTION
## Summary

Backup IDs are derived as `{hostname}-{dataset-path-with-slashes-replaced-by-dashes}` (`zfs.py:get_backup_id`). Because `-` is also a legal character in ZFS dataset name components, this flattening is **ambiguous and not reversible** — `pool/a-b` and `pool/a/b` both collapse to `pool-a-b`. That's fine for injective lookups, but you can't reconstruct a dataset path from a PBS group name (e.g. during disaster recovery, when you may not have the source host's config in hand).

This PR makes the separator configurable via **`ZPBS_BACKUP_ID_SEPARATOR`** (environment variable or config file), defaulting to `-`. A multi-character value such as `--` yields **reversible** IDs:

```
local-hdd/encrypted/device-backups  on host  s1-nas01
  ->  s1-nas01--local-hdd--encrypted--device-backups
  ->  strip the host, split("--")  ->  local-hdd/encrypted/device-backups
```

## Details

- The separator joins the hostname prefix too, so the whole ID splits uniformly.
- Validated against the PBS backup-id character set (`[A-Za-z0-9_.-]`, non-empty).
- Threaded through **every** `get_backup_id()` call site (`run`/backup, `status`, `audit`, orphan detection) so IDs stay consistent — orphan detection would break if any site used a different separator.
- **Default behavior is byte-for-byte unchanged**: `get_backup_id("h", "-")` equals the previous output, and the existing `test_get_backup_id` still passes.

## Reversibility caveat (documented in the README)

Reversibility holds only while no dataset name component contains the separator or leads/trails with `-`. The README notes this, and that changing the separator changes every ID (existing groups orphan → prune with `proxmox-backup-client` and re-seed).

## Tests

`173 passed`. Adds tests for the default, a custom `--` separator, the reversibility round-trip, empty-value fallback, and separator validation.

## Motivation

We run zpbs against datasets whose names contain dashes (`local-hdd`, `device-backups`, `gitea-repository`), where reversible, self-describing backup IDs materially help disaster recovery. Happy to adjust naming or approach (e.g. the env var name, or an opt-in `run --backup-id-separator` flag) to fit the project's preferences.
